### PR TITLE
Improve Printing Tests 

### DIFF
--- a/Common/lib/Printing/Printing.cpp
+++ b/Common/lib/Printing/Printing.cpp
@@ -1,5 +1,8 @@
 #include "Printing.h"
 #include <stdlib.h>
+#include <stdexcept>
+
+using namespace std;
 
 // Input: an integer representing a float with decimals digits past decimal multiplied by 10^decimals
 // Output: print num as a float
@@ -8,6 +11,9 @@ void printIntegerAsFloat(int num, int decimals) {
     int left = num;
     int right = num;
     int d = decimals;
+
+    if(d < 0)
+        throw invalid_argument("printIntegerAsFloat() argument decimals was negative.");
 
     if(left < 0)
         PRINT("-");
@@ -37,6 +43,9 @@ void printFloat(float num, int decimals) {
 #ifdef PRINTING
     float n = num;
     int d = decimals;
+    
+    if(d < 0)
+        throw invalid_argument("printFloat() argument decimals was negative.");
 
     int mult = 1;
     for(int i = 0; i < d; ++i)

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,8 @@ upload_protocol = stlink
 extra_scripts = pre:Common/scripts/extra_script.py
 src_filter = +<*> -<TARGET_STM32G473CET6x>
 lib_ldf_mode = chain+
+build_flags = -fexceptions
+build_unflags = -fno-exceptions
 
 [env:nucleo_f413zh_ecu]
 extends = ecu

--- a/test/test_printing/test_printing.cpp
+++ b/test/test_printing/test_printing.cpp
@@ -46,30 +46,30 @@ void tearDown()
 // Write all tests here
 void test_print()
 {
-    const char* testMessage = "Hello World!";
-    PRINT(testMessage);
+    const char* test_message = "Hello World!";
+    PRINT(test_message);
     restore_stdout();
-    TEST_ASSERT_EQUAL_STRING(testMessage, stdout_buffer);
+    TEST_ASSERT_EQUAL_STRING(test_message, stdout_buffer);
 }
 
 void test_print_integer_as_float()
 {
-    int testNum = 123;
-    int testDecimals = 2;
-    const char* expectedResult = "1.23";
-    printIntegerAsFloat(testNum, testDecimals);
+    int test_num = 123;
+    int test_decimals = 2;
+    const char* expected_result = "1.23";
+    printIntegerAsFloat(test_num, test_decimals);
     restore_stdout();
-    TEST_ASSERT_EQUAL_STRING(expectedResult, stdout_buffer);
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
 }
 
 void test_print_float()
 {
-    float testNum = 1.23f;
-    int testDecimals = 2;
-    const char* expectedResult = "1.23";
-    printFloat(testNum, testDecimals);
+    float test_num = 1.23f;
+    int test_decimals = 2;
+    const char* expected_result = "1.23";
+    printFloat(test_num, test_decimals);
     restore_stdout();
-    TEST_ASSERT_EQUAL_STRING(expectedResult, stdout_buffer);
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
 }
 
 int main()

--- a/test/test_printing/test_printing.cpp
+++ b/test/test_printing/test_printing.cpp
@@ -1,6 +1,7 @@
 #include <unity.h>
 #include <unistd.h>
 #include <cstring>
+#include <stdexcept>
 #include "Printing.h"
 
 using namespace std;
@@ -44,6 +45,8 @@ void tearDown()
 }
 
 // Write all tests here
+
+// Equivalence Test
 void test_print()
 {
     const char* test_message = "Hello World!";
@@ -52,6 +55,58 @@ void test_print()
     TEST_ASSERT_EQUAL_STRING(test_message, stdout_buffer);
 }
 
+// Boundary Test
+void test_print_empty()
+{
+    const char* test_message = "";
+    PRINT(test_message);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(test_message, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_newline()
+{
+    const char* test_message = "Hello World!\r\n";
+    PRINT(test_message);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(test_message, stdout_buffer);
+}
+
+// Equivalence Test
+void test_print_positive_integer()
+{
+    const char* test_message = "Test number is: %d";
+    int test_num = 123;
+    const char* expected_result = "Test number is: 123";
+    PRINT(test_message, test_num);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_negative_integer()
+{
+    const char* test_message = "Test number is: %d";
+    int test_num = -123;
+    const char* expected_result = "Test number is: -123";
+    PRINT(test_message, test_num);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_zero_integer()
+{
+    const char* test_message = "Test number is: %d";
+    int test_num = 0;
+    const char* expected_result = "Test number is: 0";
+    PRINT(test_message, test_num);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Equivalence Test
 void test_print_integer_as_float()
 {
     int test_num = 123;
@@ -62,6 +117,69 @@ void test_print_integer_as_float()
     TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
 }
 
+// Boundary Test
+void test_print_integer_as_float_negative()
+{
+    int test_num = -123;
+    int test_decimals = 2;
+    const char* expected_result = "-1.23";
+    printIntegerAsFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_integer_as_float_middle_zeros()
+{
+    int test_num = 1003;
+    int test_decimals = 2;
+    const char* expected_result = "10.03";
+    printIntegerAsFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_integer_as_float_trailing_zero()
+{
+    int test_num = 120;
+    int test_decimals = 2;
+    const char* expected_result = "1.20";
+    printIntegerAsFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_integer_as_float_leading_zero()
+{
+    int test_num = 123;
+    int test_decimals = 3;
+    const char* expected_result = "0.123";
+    printIntegerAsFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Exception Test
+void test_print_integer_as_float_negative_decimals()
+{
+    int test_num = 123;
+    int test_decimals = -1;
+    try
+    {
+        printIntegerAsFloat(test_num, test_decimals);
+        restore_stdout();
+        TEST_FAIL();
+    }
+    catch(invalid_argument& e)
+    {
+        restore_stdout();
+        TEST_PASS();
+    }
+}
+
+// Equivalence Test
 void test_print_float()
 {
     float test_num = 1.23f;
@@ -72,12 +190,89 @@ void test_print_float()
     TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
 }
 
+// Boundary Test
+void test_print_float_negative()
+{
+    float test_num = -1.23f;
+    int test_decimals = 2;
+    const char* expected_result = "-1.23";
+    printFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_float_middle_zeros()
+{
+    float test_num = 10.03f;
+    int test_decimals = 2;
+    const char* expected_result = "10.03";
+    printFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_float_trailing_zero()
+{
+    float test_num = 1.20f;
+    int test_decimals = 2;
+    const char* expected_result = "1.20";
+    printFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Boundary Test
+void test_print_float_leading_zero()
+{
+    float test_num = 0.123f;
+    int test_decimals = 3;
+    const char* expected_result = "0.123";
+    printFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+}
+
+// Exception Test
+void test_print_float_negative_decimals()
+{
+    float test_num = 1.23f;
+    int test_decimals = -1;
+    try
+    {
+        printFloat(test_num, test_decimals);
+        restore_stdout();
+        TEST_FAIL();
+    }
+    catch(invalid_argument& e)
+    {
+        restore_stdout();
+        TEST_PASS();
+    }
+}
+
 int main()
 {
     UNITY_BEGIN();
     RUN_TEST(test_print);
+    RUN_TEST(test_print_empty);
+    RUN_TEST(test_print_newline);
+    RUN_TEST(test_print_positive_integer);
+    RUN_TEST(test_print_negative_integer);
+    RUN_TEST(test_print_zero_integer);
     RUN_TEST(test_print_integer_as_float);
+    RUN_TEST(test_print_integer_as_float_negative);
+    RUN_TEST(test_print_integer_as_float_middle_zeros);
+    RUN_TEST(test_print_integer_as_float_trailing_zero);
+    RUN_TEST(test_print_integer_as_float_leading_zero);
+    RUN_TEST(test_print_integer_as_float_negative_decimals);
     RUN_TEST(test_print_float);
+    RUN_TEST(test_print_float_negative);
+    RUN_TEST(test_print_float_middle_zeros);
+    RUN_TEST(test_print_float_trailing_zero);
+    RUN_TEST(test_print_float_leading_zero);
+    RUN_TEST(test_print_float_negative_decimals);
     UNITY_END();
 
 #ifndef NATIVE


### PR DESCRIPTION
Improved `Printing` unit tests:
* Change style of variable names from camelCase to snake_case
* Add many boundary and a few exception tests labeled with a comment
* Enable C++ exceptions for all envs via build flag in `platformio.ini`
* Add exception handling of negative decimal input values using `<stdexception>`  to `Printing.c`