### PR TITLE
Remove exceptions

### DIFF
--- a/Common/include/README.md
+++ b/Common/include/README.md
@@ -1,0 +1,3 @@
+# Include
+
+Place all files that have only a `.h` here.

--- a/Common/lib/Printing/Printing.cpp
+++ b/Common/lib/Printing/Printing.cpp
@@ -1,6 +1,5 @@
 #include "Printing.h"
 #include <stdlib.h>
-#include <stdexcept>
 
 using namespace std;
 
@@ -13,7 +12,10 @@ void printIntegerAsFloat(int num, int decimals) {
     int d = decimals;
 
     if(d < 0)
-        throw invalid_argument("printIntegerAsFloat() argument decimals was negative.");
+    {
+        PRINT("ERROR: printIntegerAsFloat() argument decimals was negative.");
+        return;
+    }
 
     if(left < 0)
         PRINT("-");
@@ -45,7 +47,10 @@ void printFloat(float num, int decimals) {
     int d = decimals;
     
     if(d < 0)
-        throw invalid_argument("printFloat() argument decimals was negative.");
+    {
+        PRINT("ERROR: printFloat() argument decimals was negative.");
+        return;
+    }
 
     int mult = 1;
     for(int i = 0; i < d; ++i)

--- a/Common/lib/README.md
+++ b/Common/lib/README.md
@@ -1,0 +1,3 @@
+# Lib
+
+Place all files that have a `.cpp` and associated `.h` here.

--- a/Common/src/README.md
+++ b/Common/src/README.md
@@ -1,0 +1,6 @@
+# Src
+
+Place all files that have only a `.cpp` here.
+
+Note: because this is the Common directory, this should not include a `main.cpp`
+and only include a custom target for the MCU we are using.

--- a/ECU/include/README.md
+++ b/ECU/include/README.md
@@ -1,0 +1,3 @@
+# Include
+
+Place all files that have only a `.h` here.

--- a/ECU/lib/README.md
+++ b/ECU/lib/README.md
@@ -1,0 +1,3 @@
+# Lib
+
+Place all files that have a `.cpp` and associated `.h` here.

--- a/ECU/src/README.md
+++ b/ECU/src/README.md
@@ -1,0 +1,5 @@
+# Src
+
+Place all files that have only a `.cpp` here.
+
+Note: this should only include `main.cpp`.

--- a/Motor/include/README.md
+++ b/Motor/include/README.md
@@ -1,0 +1,3 @@
+# Include
+
+Place all files that have only a `.h` here.

--- a/Motor/lib/README.md
+++ b/Motor/lib/README.md
@@ -1,0 +1,3 @@
+# Lib
+
+Place all files that have a `.cpp` and associated `.h` here.

--- a/Motor/src/README.md
+++ b/Motor/src/README.md
@@ -1,0 +1,5 @@
+# Src
+
+Place all files that have only a `.cpp` here.
+
+Note: this should only include `main.cpp`.

--- a/PowerAux/include/README.md
+++ b/PowerAux/include/README.md
@@ -1,0 +1,3 @@
+# Include
+
+Place all files that have only a `.h` here.

--- a/PowerAux/lib/README.md
+++ b/PowerAux/lib/README.md
@@ -1,0 +1,3 @@
+# Lib
+
+Place all files that have a `.cpp` and associated `.h` here.

--- a/PowerAux/src/README.md
+++ b/PowerAux/src/README.md
@@ -1,0 +1,5 @@
+# Src
+
+Place all files that have only a `.cpp` here.
+
+Note: this should only include `main.cpp`.

--- a/Solar/include/README.md
+++ b/Solar/include/README.md
@@ -1,0 +1,3 @@
+# Include
+
+Place all files that have only a `.h` here.

--- a/Solar/lib/README.md
+++ b/Solar/lib/README.md
@@ -1,0 +1,3 @@
+# Lib
+
+Place all files that have a `.cpp` and associated `.h` here.

--- a/Solar/src/README.md
+++ b/Solar/src/README.md
@@ -1,0 +1,5 @@
+# Src
+
+Place all files that have only a `.cpp` here.
+
+Note: this should only include `main.cpp`.

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,8 +16,6 @@ upload_protocol = stlink
 extra_scripts = pre:Common/scripts/extra_script.py
 src_filter = +<*> -<TARGET_STM32G473CET6x>
 lib_ldf_mode = chain+
-build_flags = -fexceptions
-build_unflags = -fno-exceptions
 
 [env:nucleo_f413zh_ecu]
 extends = ecu

--- a/test/test_printing/test_printing.cpp
+++ b/test/test_printing/test_printing.cpp
@@ -1,7 +1,6 @@
 #include <unity.h>
 #include <unistd.h>
 #include <cstring>
-#include <stdexcept>
 #include "Printing.h"
 
 using namespace std;
@@ -166,17 +165,10 @@ void test_print_integer_as_float_negative_decimals()
 {
     int test_num = 123;
     int test_decimals = -1;
-    try
-    {
-        printIntegerAsFloat(test_num, test_decimals);
-        restore_stdout();
-        TEST_FAIL();
-    }
-    catch(invalid_argument& e)
-    {
-        restore_stdout();
-        TEST_PASS();
-    }
+    const char* expected_result = "ERROR: printIntegerAsFloat() argument decimals was negative.";
+    printIntegerAsFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
 }
 
 // Equivalence Test
@@ -239,17 +231,11 @@ void test_print_float_negative_decimals()
 {
     float test_num = 1.23f;
     int test_decimals = -1;
-    try
-    {
-        printFloat(test_num, test_decimals);
-        restore_stdout();
-        TEST_FAIL();
-    }
-    catch(invalid_argument& e)
-    {
-        restore_stdout();
-        TEST_PASS();
-    }
+    const char* expected_result = "ERROR: printFloat() argument decimals was negative.";
+    printFloat(test_num, test_decimals);
+    restore_stdout();
+    TEST_ASSERT_EQUAL_STRING(expected_result, stdout_buffer);
+
 }
 
 int main()


### PR DESCRIPTION
Remove exceptions from `Printing.cpp` and `test_printing.h`, since we don't want embedded systems to crash during operation. Replaced the exceptions with error print statements. Re-disabled C++ exceptions in the `platformio.ini` file.

Also added a `README.md` to each team's `src`, `lib`, and `include` directories (this also allows us to commit the empty `lib` directory to Git).