### PR TITLE
Add Code Coverage

### DIFF
--- a/.circleci/.coveralls.yml
+++ b/.circleci/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: circle-ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run:
           name: Set up
           command: |
+            sudo apt update
             pip install --upgrade pipenv
             pipenv install
             pipenv run pio update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,11 @@
-version: 2
+version: 2.1
+orbs:
+  coveralls: coveralls/coveralls@1.0.6
 jobs:
   build:
     docker:
-      - image: cimg/python:3.9
-        environment:
+      - image: cimg/python:3.9-node
+        # environment:
           # PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
@@ -36,7 +38,8 @@ jobs:
           command: |
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
-            pipenv run coveralls -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/
+            sudo apt install lcov
+            lcov --capture --directory . --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
@@ -45,3 +48,5 @@ jobs:
           key: platformio-v7-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
       - store_artifacts:
           path: .coverage
+      - coveralls/upload
+          path_to_lcov: .coverage/coverage.info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,4 +49,4 @@ jobs:
       - store_artifacts:
           path: .coverage
       - coveralls/upload
-          path_to_lcov: .coverage/coverage.info
+          path_to_lcov: ".coverage/coverage.info"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
             sudo apt install lcov
-            lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/" --exclude "*/Common/lib/MbedMock/" --exclude "*/test/" --output-file .coverage/coverage.info
+            lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/*" --exclude "*/Common/lib/MbedMock/*" --exclude "*/test/*" --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
             sudo apt install lcov
-            lcov --capture --base-directory . --directory . --no-external --exclude Common/lib/FakeIt/ --exclude Common/lib/MbedMock/ --exclude test/ --output-file .coverage/coverage.info
+            lcov --capture --base-directory . --directory . --no-external --exclude */Common/lib/FakeIt/ --exclude */Common/lib/MbedMock/ --exclude */test/ --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,5 +48,5 @@ jobs:
           key: platformio-v7-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
       - store_artifacts:
           path: .coverage
-      - coveralls/upload
-          path_to_lcov: ".coverage/coverage.info"
+      - coveralls/upload:
+          path_to_lcov: .coverage/coverage.info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,7 @@ jobs:
       - run:
           name: Coverage
           command: |
+            mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       - image: cimg/python:3.9
-        # environment:
+        environment:
           # PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
@@ -36,7 +36,7 @@ jobs:
           command: |
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
-            pipenv run coveralls -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/
+            TRAVIS_JOB_ID="#${CIRCLE_BUILD_NUM}" pipenv run coveralls -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,8 @@ jobs:
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
             sudo apt install lcov
-            lcov --capture --directory . --output-file .coverage/coverage.info
+            lcov --capture --base-directory . --directory . --output-file .coverage/coverage.info
+            lcov --remove .coverage/coverage.info Common/lib/FakeIt/ Common/lib/MbedMock/ test/ --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
             sudo apt install lcov
             lcov --capture --base-directory . --directory . --output-file .coverage/coverage.info
-            lcov --remove .coverage/coverage.info Common/lib/FakeIt/ Common/lib/MbedMock/ test/ --output-file .coverage/coverage.info
+            lcov --remove .coverage/coverage.info */Common/lib/FakeIt/ */Common/lib/MbedMock/ */test/ /usr/include/ ~/.platformio/ --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
           command: |
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
-            TRAVIS_JOB_ID="#${CIRCLE_BUILD_NUM}" pipenv run coveralls -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/
+            pipenv run coveralls -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,7 @@ jobs:
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
             sudo apt install lcov
-            lcov --capture --base-directory . --directory . --output-file .coverage/coverage.info
-            lcov --remove .coverage/coverage.info */Common/lib/FakeIt/ */Common/lib/MbedMock/ */test/ /usr/include/ ~/.platformio/ --output-file .coverage/coverage.info
+            lcov --capture --base-directory . --directory . --no-external --exclude Common/lib/FakeIt/ --exclude Common/lib/MbedMock/ --exclude test/ --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
           command: |
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
+            pipenv run coveralls -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,10 +12,10 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - platformio-v6-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
-            - platformio-v6-{{ .Branch }}-{{ checksum "Pipfile" }}-
-            - platformio-v6-{{ .Branch }}-
-            - platformio-v6-
+            - platformio-v7-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
+            - platformio-v7-{{ .Branch }}-{{ checksum "Pipfile" }}-
+            - platformio-v7-{{ .Branch }}-
+            - platformio-v7-
       - run:
           name: Set up
           command: |
@@ -31,9 +31,15 @@ jobs:
           name: Test
           command: |
             pipenv run pio test -e native
+      - run:
+          name: Coverage
+          command: |
+            pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
             - ~/.platformio/cache
-          key: platformio-v6-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
-        
+            - .pio
+          key: platformio-v7-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
+      - store_artifacts:
+          path: .coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             mkdir .coverage
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
             sudo apt install lcov
-            lcov --capture --base-directory . --directory . --no-external --exclude */Common/lib/FakeIt/ --exclude */Common/lib/MbedMock/ --exclude */test/ --output-file .coverage/coverage.info
+            lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/" --exclude "*/Common/lib/MbedMock/" --exclude "*/test/" --output-file .coverage/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ __pycache__
 *.exe
 *.out
 *.app
+
+# Coverage reports
+.coverage

--- a/Common/scripts/enable_coverage.py
+++ b/Common/scripts/enable_coverage.py
@@ -1,0 +1,2 @@
+Import("env")
+env.Append(LINKFLAGS=["--coverage"])

--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 platformio = "*"
+gcovr = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 platformio = "*"
 gcovr = "*"
+cpp-coveralls = "*"
 
 [requires]
 python_version = "3.9"

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 platformio = "*"
 gcovr = "*"
-cpp-coveralls = "*"
 
 [requires]
 python_version = "3.9"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Template Code
+[![CircleCI](https://circleci.com/gh/solarcaratuva/TemplateCode.svg?style=shield)](https://circleci.com/gh/solarcaratuva/TemplateCode)
+[![Coverage Status](https://coveralls.io/repos/github/solarcaratuva/TemplateCode/badge.svg)](https://coveralls.io/github/solarcaratuva/TemplateCode)
+
 UVA Solar Car Template code repository. This repository contains the embedded systems template dev environment setup to be used by all boards.
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -110,6 +110,7 @@ src_filter = ${solar.src_filter} ${uva_solar_car.src_filter}
 [env:native]
 platform = native
 framework = ; blank indicates no framework
-build_flags = ${env.build_flags} -D NATIVE
+build_flags = ${env.build_flags} -D NATIVE --coverage
 lib_extra_dirs = ECU/lib Motor/lib PowerAux/lib Solar/lib
 lib_ignore = ; blank indicates to not ignore MbedMock and FakeIt
+extra_scripts = ${env.extra_scripts}, Common/scripts/enable_coverage.py


### PR DESCRIPTION
Add code coverage reports available both as a CircleCI build artifact and on Coveralls.io

Also added status and code coverage badges to the Readme

Code coverage is currently only calculated for these folders:
* Everything in `Common/lib` except for `FakeIt` and `MbedMock`
* `ECU/lib`
* `Motor/lib`
* `PowerAux/lib`
* `Solar/lib`

That is, the `FakeIt` and `MbedMock` libraries are ignored, as well as everything under `test` and all `src` and `lib` folders

Also, note that coverage is only calculated for *source* code, so typically this means all `.h` files are excluded from coverage reports, and only the `.cpp` files are included. Header files may be included if there is any function, constructor, destructor, etc. definitions in them, which should often not be the case.