### PR TITLE
Speed Up Coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
           command: |
             mkdir -p .coverage/input .coverage/output
             shopt -s globstar
-            cp .pio/**/*.gcno .coverage/input
-            cp .pio/**/*.gcda .coverage/input
+            cp .pio/**/*.gcno .coverage/input || :
+            cp .pio/**/*.gcda .coverage/input || :
             pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/output/coverage.html
             sudo apt install lcov
             lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/*" --exclude "*/Common/lib/MbedMock/*" --exclude "*/test/*" --output-file .coverage/input/coverage.info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ jobs:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
             - ~/.platformio/cache
-            - .pio
             - .coverage
           key: platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,17 +37,21 @@ jobs:
       - run:
           name: Coverage
           command: |
-            mkdir .coverage
-            pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/coverage.html
+            mkdir -p .coverage/input .coverage/output
+            shopt -s globstar
+            cp .pio/**/*.gcno .coverage/input
+            cp .pio/**/*.gcda .coverage/input
+            pipenv run gcovr -e Common/lib/FakeIt/ -e Common/lib/MbedMock/ -e test/ --html-details -o .coverage/output/coverage.html
             sudo apt install lcov
-            lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/*" --exclude "*/Common/lib/MbedMock/*" --exclude "*/test/*" --output-file .coverage/coverage.info
+            lcov --capture --base-directory . --directory . --no-external --exclude "*/Common/lib/FakeIt/*" --exclude "*/Common/lib/MbedMock/*" --exclude "*/test/*" --output-file .coverage/input/coverage.info
       - save_cache:
           paths:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
-            # - ~/.platformio/cache
+            - ~/.platformio/cache
             - .pio
+            - .coverage
           key: platformio-v8-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
       - store_artifacts:
-          path: .coverage
+          path: .coverage/output
       - coveralls/upload:
-          path_to_lcov: .coverage/coverage.info
+          path_to_lcov: .coverage/input/coverage.info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - platformio-v8-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
-            - platformio-v8-{{ .Branch }}-{{ checksum "Pipfile" }}-
-            - platformio-v8-{{ .Branch }}-
-            - platformio-v8-
+            - platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
+            - platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-
+            - platformio-v9-{{ .Branch }}-
+            - platformio-v9-
       - run:
           name: Set up
           command: |
@@ -50,7 +50,7 @@ jobs:
             - ~/.platformio/cache
             - .pio
             - .coverage
-          key: platformio-v8-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
+          key: platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
       - store_artifacts:
           path: .coverage/output
       - coveralls/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,11 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
-            - platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-
-            - platformio-v9-{{ .Branch }}-
-            - platformio-v9-
+            - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci" }}
+            - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
+            - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-
+            - platformio-v10-{{ .Branch }}-
+            - platformio-v10-
       - run:
           name: Set up
           command: |
@@ -49,7 +50,7 @@ jobs:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
             - ~/.platformio/cache
             - .coverage
-          key: platformio-v9-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
+          key: platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci" }}
       - store_artifacts:
           path: .coverage/output
       - coveralls/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - restore_cache:
           keys:
             # when lock file changes, use increasingly general patterns to restore cache
-            - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci" }}
+            - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci/config.yml" }}
             - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}
             - platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-
             - platformio-v10-{{ .Branch }}-
@@ -50,7 +50,7 @@ jobs:
             - ~/.local/share/virtualenvs  # this path depends on where pipenv creates a virtualenv
             - ~/.platformio/cache
             - .coverage
-          key: platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci" }}
+          key: platformio-v10-{{ .Branch }}-{{ checksum "Pipfile" }}-{{ checksum "platformio.ini" }}-{{ checksum ".circleci/config.yml" }}
       - store_artifacts:
           path: .coverage/output
       - coveralls/upload:


### PR DESCRIPTION
CircleCI builds were often rebuilding all of Mbed and other dependencies. This PR fixes that and speeds up coverage by caching the coverage files in CircleCI