### PR TITLE
Determine CAN Message ID 

### DIFF
--- a/Common/lib/CANParser/CANParser.h
+++ b/Common/lib/CANParser/CANParser.h
@@ -4,12 +4,11 @@
 #include <mbed.h>
 #include <queue>
 
-// TODO: determine & change the message ID format (# of bits for node ID vs priority) 
-// CAN message ID (11 bits): Node ID stored in bottom 7 bits (bits 0-6),
-//                           Priority stored in next 4 bits (bits 7-10)
-#define CAN_MESSAGE_ID(NODE_ID, PRIORITY)   ((NODE_ID&0x7F)|((PRIORITY&0x0F)<<7))
-#define CAN_NODE_ID(CAN_MESSAGE_ID)         (CAN_MESSAGE_ID&0x7F)
-#define CAN_PRIORITY(CAN_MESSAGE_ID)        ((CAN_MESSAGE_ID>>7)&0x0F)
+// CAN message ID (11 bits): Node ID stored in bottom 3 bits (bits 0-2),
+//                           Priority stored in upper 8 bits (bits 3-10)
+#define CAN_MESSAGE_ID(NODE_ID, PRIORITY)   ((NODE_ID&0x07)|((PRIORITY&0xFF)<<3))
+#define CAN_NODE_ID(CAN_MESSAGE_ID)         (CAN_MESSAGE_ID&0x07)
+#define CAN_PRIORITY(CAN_MESSAGE_ID)        ((CAN_MESSAGE_ID>>7)&0xFF)
 
 #define MAX_CAN_DATA_SIZE_BITS  64
 #define MAX_CAN_DATA_SIZE_BYTES 8


### PR DESCRIPTION
Fix CAN message id to allocate 3 bits for node id (supports up to 8 nodes) and 8 bits for priority 