### PR TITLE
Refactor CANInterface to support RX interrupts

### DIFF
--- a/Common/lib/CANInterface/CANInterface.h
+++ b/Common/lib/CANInterface/CANInterface.h
@@ -3,26 +3,29 @@
 
 #include <mbed.h>
 #include "CANParser.h"
+#include "NoMutexCAN.h"
 
 class CANInterface
 {
 public:
-    CANInterface(CAN &c, CANParser &cp, Thread &tx_thread, Thread &rx_thread, DigitalOut *stby=nullptr, std::chrono::milliseconds can_period = 1s);
-    void startCANTransmission(void);
+    CANInterface(PinName rd, PinName td, CANParser &cp, Thread &rx_thread, Thread &tx_thread, DigitalOut *stby=nullptr, std::chrono::milliseconds can_period = 1s, int rx_queue_size = 64);
+    void start_CAN_transmission(void);
 
 private:
-    void rx_handler(void);
+    void rx_isr(void);
+    void rx_handler(CANMessage message);
     void tx_handler(void);
 
-    CAN &can;
+    NoMutexCAN can;
     CANParser &can_parser;
     DigitalOut *standby;
 
-    Thread &tx_thread;
     Thread &rx_thread;
+    Thread &tx_thread;
 
     std::chrono::milliseconds tx_period;
 
+    EventQueue rx_queue;
 };
 
 #endif

--- a/Common/lib/CANInterface/NoMutexCAN.h
+++ b/Common/lib/CANInterface/NoMutexCAN.h
@@ -1,0 +1,36 @@
+/*
+MIT License
+Copyright (c) 2019 Pavel Slama
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef NOMUTEXCAN_H
+#define NOMUTEXCAN_H
+
+#include "mbed.h"
+
+
+class NoMutexCAN: public CAN {
+  public:
+    NoMutexCAN(PinName rd, PinName td): CAN(rd, td) {}
+    NoMutexCAN(PinName rd, PinName td, int hz): CAN(rd, td, hz) {}
+    virtual ~NoMutexCAN() {};
+    void lock() override {};
+    void unlock() override {};
+};
+
+#endif  // NOMUTEXCAN_H

--- a/PowerAux/src/main.cpp
+++ b/PowerAux/src/main.cpp
@@ -13,20 +13,18 @@
 
 BufferedSerial device(USBTX, USBRX);
 
-CAN bms_can(CAN_RX, CAN_TX);
 DigitalOut bms_can_stby(CAN_STBY);
-Thread bms_can_tx_thread;
 Thread bms_can_rx_thread;
+Thread bms_can_tx_thread;
 
-CAN vehicle_can(CAN2_RX, CAN2_TX);
 DigitalOut vehicle_can_stby(CAN2_STBY);
-Thread vehicle_can_tx_thread;
 Thread vehicle_can_rx_thread;
+Thread vehicle_can_tx_thread;
 
 PowerAuxCANParser bms_can_parser;
 PowerAuxCANParser vehicle_can_parser;
-CANInterface bms_can_interface(bms_can, bms_can_parser, bms_can_tx_thread, bms_can_rx_thread, &bms_can_stby, CAN_PERIOD);
-CANInterface vehicle_can_interface(vehicle_can, vehicle_can_parser, vehicle_can_tx_thread, vehicle_can_rx_thread, &vehicle_can_stby, CAN_PERIOD);
+CANInterface bms_can_interface(CAN_RX, CAN_TX, bms_can_parser, bms_can_rx_thread, bms_can_tx_thread, &bms_can_stby, CAN_PERIOD);
+CANInterface vehicle_can_interface(CAN2_RX, CAN2_TX, vehicle_can_parser, vehicle_can_rx_thread, vehicle_can_tx_thread, &vehicle_can_stby, CAN_PERIOD);
 
 int main() {
     // device.set_baud(38400);
@@ -35,8 +33,8 @@ int main() {
     PRINT("start main() \r\n");
 #endif //TESTING
     
-    bms_can_interface.startCANTransmission();
-    vehicle_can_interface.startCANTransmission();
+    bms_can_interface.start_CAN_transmission();
+    vehicle_can_interface.start_CAN_transmission();
 
     while(1){
         #ifdef TESTING

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -4,7 +4,8 @@
         "target.c_lib": "small",
         "target.printf_lib": "minimal-printf",
         "platform.minimal-printf-enable-floating-point": false,
-        "platform.stdio-minimal-console-only": true
+        "platform.stdio-minimal-console-only": true,
+        "platform.callback-nontrivial": true
       }
     }
 }


### PR DESCRIPTION
Closes #18. This PR adds support for RX interrupts by adding a queue (with a default size of 64 CAN messages) of Mbed events. In the `rx_isr()` method, CAN messages are added to the queue. In the `rx_handler()` method, messages are processed by calling `can_parser.parse()`. 

Notably, this PR relies on disabling the mutex in the Mbed CAN class. This allows for `can.read()` to be called in an ISR context, even with RTOS enabled. This is accomplished in the new `NoMutexCAN.h` file. 

However, I'm not sure if CAN is thread-safe in our use case. If it is not, then this PR should not be merged.