### PR TITLE
clang-tidy integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,12 @@ jobs:
           command: |
             pipenv run pio test -e native
       - run:
+          name: Lint
+          command: |
+            sudo apt install -y libtinfo5
+            sudo ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.5 
+            pipenv run pio check -e native -v
+      - run:
           name: Coverage
           command: |
             mkdir -p .coverage/input .coverage/output

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run:
           name: Lint
           command: |
-            pipenv run pio check -e native
+            pipenv run pio check -e native -v
       - run:
           name: Test
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
           name: Lint
           command: |
             sudo apt-get install -y clang-tidy
+            mkdir -p /home/circleci/.platformio/packages/tool-clangtidy/
             ln -sf /usr/bin/clang-tidy /home/circleci/.platformio/packages/tool-clangtidy/clang-tidy
             pipenv run pio check -e native -v
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ jobs:
           name: Lint
           command: |
             sudo apt install -y libtinfo5
-            pipenv run pio check -e native -v
+            pipenv run pio check --fail-on-defect high -e native
       - run:
           name: Coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,6 @@ jobs:
           command: |
             pipenv run pio run -e ecu -e motor -e power_aux -e solar -e nucleo_f413zh_ecu
       - run:
-          name: Lint
-          command: |
-            sudo apt-get install -y clang-tidy
-            mkdir -p /home/circleci/.platformio/packages/tool-clangtidy/
-            ln -sf /usr/bin/clang-tidy /home/circleci/.platformio/packages/tool-clangtidy/clang-tidy
-            pipenv run pio check -e native -v
-      - run:
           name: Test
           command: |
             pipenv run pio test -e native

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ jobs:
           name: Lint
           command: |
             sudo apt install -y libtinfo5
-            sudo ln -s /lib/x86_64-linux-gnu/libtinfo.so.6 /lib/x86_64-linux-gnu/libtinfo.so.5 
             pipenv run pio check -e native -v
       - run:
           name: Coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,8 @@ jobs:
       - run:
           name: Lint
           command: |
+            sudo apt-get install -y clang-tidy
+            ln -sf /usr/bin/clang-tidy /home/circleci/.platformio/packages/tool-clangtidy/clang-tidy
             pipenv run pio check -e native -v
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ jobs:
           command: |
             pipenv run pio run -e ecu -e motor -e power_aux -e solar -e nucleo_f413zh_ecu
       - run:
+          name: Lint
+          command: |
+            pipenv run pio check -e native
+      - run:
           name: Test
           command: |
             pipenv run pio test -e native

--- a/platformio.ini
+++ b/platformio.ini
@@ -126,3 +126,4 @@ check_patterns =
     Motor/
     PowerAux/
     Solar/
+    test/

--- a/platformio.ini
+++ b/platformio.ini
@@ -121,7 +121,8 @@ lib_extra_dirs = ECU/lib Motor/lib PowerAux/lib Solar/lib
 lib_ignore = ; blank indicates to not ignore MbedMock and FakeIt
 extra_scripts = ${env.extra_scripts}, Common/scripts/enable_coverage.py
 check_patterns = 
-    Common/
+    Common/[!lib]*
+    Common/lib/[!FakeIt][!MbedMock]*
     ECU/
     Motor/
     PowerAux/

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,6 +18,8 @@ src_filter = +<*> -<TARGET_STM32G473CET6x>
 lib_ldf_mode = chain+
 lib_ignore = MbedMock, FakeIt
 
+check_tool = clangtidy
+
 [env:nucleo_f413zh_ecu]
 extends = ecu
 board = nucleo_f413zh
@@ -71,6 +73,7 @@ src_filter = +<TARGET_STM32G473CET6x>
 build_flags = ${env.build_flags} -I ECU/include
 lib_extra_dirs = ECU/lib
 src_filter = ${env.src_filter} +<../../ECU/src>
+check_patterns = ECU/
 
 [env:ecu]
 extends = uva_solar_car, ecu
@@ -81,6 +84,7 @@ src_filter = ${ecu.src_filter} ${uva_solar_car.src_filter}
 build_flags = ${env.build_flags} -I Motor/include
 lib_extra_dirs = Motor/lib
 src_filter = ${env.src_filter} +<../../Motor/src>
+check_patterns = Motor/
 
 [env:motor]
 extends = uva_solar_car, motor
@@ -91,6 +95,7 @@ src_filter = ${motor.src_filter} ${uva_solar_car.src_filter}
 build_flags = ${env.build_flags} -I PowerAux/include
 lib_extra_dirs = PowerAux/lib
 src_filter = ${env.src_filter} +<../../PowerAux/src>
+check_patterns = PowerAux/
 
 [env:power_aux]
 extends = uva_solar_car, power_aux
@@ -101,6 +106,7 @@ src_filter = ${power_aux.src_filter} ${uva_solar_car.src_filter}
 build_flags = ${env.build_flags} -I Solar/include
 lib_extra_dirs = Solar/lib
 src_filter = ${env.src_filter} +<../../Solar/src>
+check_patterns = Solar/
 
 [env:solar]
 extends = uva_solar_car, solar
@@ -114,3 +120,9 @@ build_flags = ${env.build_flags} -D NATIVE --coverage
 lib_extra_dirs = ECU/lib Motor/lib PowerAux/lib Solar/lib
 lib_ignore = ; blank indicates to not ignore MbedMock and FakeIt
 extra_scripts = ${env.extra_scripts}, Common/scripts/enable_coverage.py
+check_patterns = 
+    Common/
+    ECU/
+    Motor/
+    PowerAux/
+    Solar/


### PR DESCRIPTION
This PR adds clang-tidy and closes #13. To lint the code, run `pio check -e ENVIRONMENT_NAME`. I set it up so that each environment only lints its own code. For example, running `pio check -e power_aux` only lints code in `PowerAux/`. I did not know which environments should lint `Common/` and `test/`, so they only run in the `native` environment. Let me know if you want me to change this behavior.

As for CircleCI, running `/home/circleci/.platformio/packages/tool-clangtidy/clang-tidy` returns `/home/circleci/.platformio/packages/tool-clangtidy/clang-tidy: error while loading shared libraries: libtinfo.so.5: cannot open shared object file: No such file or directory`.