### PR TITLE
Update Mbed to v6.9

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@ src_dir = Common/src
 [env]
 platform = ststm32 @ ^11.0.0
 framework = mbed
-platform_packages = framework-mbed @ ^6.60600.0
+platform_packages = framework-mbed @ >=6.60900.0,<7.0.0
 debug_tool = stlink
 upload_protocol = stlink
 


### PR DESCRIPTION
This PR updates the minimum required version of Mbed to v6.9